### PR TITLE
Reduce number of imports

### DIFF
--- a/tests/Ad/DELETE_user_userID_ad_adID.test.js
+++ b/tests/Ad/DELETE_user_userID_ad_adID.test.js
@@ -9,12 +9,7 @@ const app = require("../../index.js");
 
 // Import functions from AdService that we want to test
 const {
-  userUserIDAdGET,
-  userUserIDAdAdIDGET,
-  userUserIDAdPOST,
-  adGET,
   userUserIDAdAdIDDELETE,
-  adAdIDPUT,
 } = require("../../service/AdService.js");
 
 // Before each test, start the server and save the connection information  (host/port).

--- a/tests/Ad/GET_ad.test.js
+++ b/tests/Ad/GET_ad.test.js
@@ -9,12 +9,7 @@ const app = require("../../index.js");
 
 // Import functions from AdService that we want to test
 const {
-  userUserIDAdGET,
-  userUserIDAdAdIDGET,
-  userUserIDAdPOST,
   adGET,
-  userUserIDAdAdIDDELETE,
-  adAdIDPUT,
 } = require("../../service/AdService.js");
 
 // Before each test, start the server and save the connection information  (host/port).

--- a/tests/Ad/GET_user_userID_ad.test.js
+++ b/tests/Ad/GET_user_userID_ad.test.js
@@ -10,11 +10,6 @@ const app = require("../../index.js");
 // Import functions from AdService that we want to test
 const {
   userUserIDAdGET,
-  userUserIDAdAdIDGET,
-  userUserIDAdPOST,
-  adGET,
-  userUserIDAdAdIDDELETE,
-  adAdIDPUT,
 } = require("../../service/AdService.js");
 
 // Before each test, start the server and save the connection information  (host/port).

--- a/tests/Ad/GET_user_userID_ad_adID.test.js
+++ b/tests/Ad/GET_user_userID_ad_adID.test.js
@@ -9,12 +9,7 @@ const app = require("../../index.js");
 
 // Import functions from AdService that we want to test
 const {
-  userUserIDAdGET,
   userUserIDAdAdIDGET,
-  userUserIDAdPOST,
-  adGET,
-  userUserIDAdAdIDDELETE,
-  adAdIDPUT,
 } = require("../../service/AdService.js");
 
 // Before each test, start the server and save the connection information  (host/port).

--- a/tests/Ad/POST_user_userID_ad.test.js
+++ b/tests/Ad/POST_user_userID_ad.test.js
@@ -9,12 +9,7 @@ const app = require("../../index.js");
 
 // Import functions from AdService that we want to test
 const {
-  userUserIDAdGET,
-  userUserIDAdAdIDGET,
   userUserIDAdPOST,
-  adGET,
-  userUserIDAdAdIDDELETE,
-  adAdIDPUT,
 } = require("../../service/AdService.js");
 
 // Before each test, start the server and save the connection information  (host/port).

--- a/tests/Ad/PUT_ad_adID.test.js
+++ b/tests/Ad/PUT_ad_adID.test.js
@@ -9,11 +9,6 @@ const app = require("../../index.js");
 
 // Import functions from AdService that we want to test
 const {
-  userUserIDAdGET,
-  userUserIDAdAdIDGET,
-  userUserIDAdPOST,
-  adGET,
-  userUserIDAdAdIDDELETE,
   adAdIDPUT,
 } = require("../../service/AdService.js");
 

--- a/tests/User/DELETE_user_userID.test.js
+++ b/tests/User/DELETE_user_userID.test.js
@@ -5,15 +5,7 @@ const got = require("got");
 const app = require("../../index.js");
 const {
   userUserIDDELETE,
-  userUserIDProfile_picturePUT,
-  userPOST,
-  userUserIDGET,
-  userGET,
-  userUserIDPUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);

--- a/tests/User/GET_user.test.js
+++ b/tests/User/GET_user.test.js
@@ -4,16 +4,8 @@ const listen = require("test-listen");
 const got = require("got");
 const app = require("../../index.js");
 const {
-  userUserIDDELETE,
-  userUserIDProfile_picturePUT,
-  userPOST,
-  userUserIDGET,
   userGET,
-  userUserIDPUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);

--- a/tests/User/GET_user_userID.test.js
+++ b/tests/User/GET_user_userID.test.js
@@ -4,16 +4,8 @@ const listen = require("test-listen");
 const got = require("got");
 const app = require("../../index.js");
 const {
-  userUserIDDELETE,
-  userUserIDProfile_picturePUT,
-  userPOST,
   userUserIDGET,
-  userGET,
-  userUserIDPUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);

--- a/tests/User/POST_user.test.js
+++ b/tests/User/POST_user.test.js
@@ -4,16 +4,8 @@ const listen = require("test-listen");
 const got = require("got");
 const app = require("../../index.js");
 const {
-  userUserIDDELETE,
-  userUserIDProfile_picturePUT,
   userPOST,
-  userUserIDGET,
-  userGET,
-  userUserIDPUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);

--- a/tests/User/PUT_user_userID.test.js
+++ b/tests/User/PUT_user_userID.test.js
@@ -4,16 +4,8 @@ const listen = require("test-listen");
 const got = require("got");
 const app = require("../../index.js");
 const {
-  userUserIDDELETE,
-  userUserIDProfile_picturePUT,
-  userPOST,
-  userUserIDGET,
-  userGET,
   userUserIDPUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);
@@ -81,7 +73,6 @@ test("PUT user information | endpoint should work successfully", async (t) => {
 
   t.is(statusCode, 200);
 
-  const randUser = body[0];
 
   t.is(body.userDescription, "userDescription");
   t.is(body.gender, "gender");

--- a/tests/User/PUT_user_userID_profile-picture.test.js
+++ b/tests/User/PUT_user_userID_profile-picture.test.js
@@ -6,9 +6,7 @@ const app = require("../../index.js");
 const {
   userUserIDProfile_picturePUT,
 } = require("../../service/UserService.js");
-const { FormData, File } = require("formdata-node");
-const { FormDataEncoder } = require("form-data-encoder");
-const { Readable } = require("stream");
+const { getFormDataDetails } = require('../../utils/formDataUtils.js');
 
 test.before(async (t) => {
   t.context.server = http.createServer(app);
@@ -33,19 +31,16 @@ test("Upload Profile Picture | calling the function should work successfully", a
 test("Upload Profile Picture | endpoint should work successfully", async (t) => {
   const userId = 1;
 
-  const formData = new FormData();
-  const file = new File(["example content"], "profilePicture.png");
-  formData.set("file", file);
+  const { requestBody, requestHeaders } = getFormDataDetails({
+    formDataFieldName: 'file',
+    fileContent: 'example content',
+    fileName: 'profilePicture.png',
+  });
 
-  const encoder = new FormDataEncoder(formData);
-
-  const { body, statusCode } = await t.context.got.put(
-    `user/${userId}/profile-picture`,
-    {
-      body: Readable.from(encoder.encode()),
-      headers: encoder.headers,
-    },
-  );
+  const { body, statusCode } = await t.context.got.put(`user/${userId}/profile-picture`, {
+    body: requestBody,
+    headers: requestHeaders,
+  });
   t.is(statusCode, 200);
   t.is(body.message, "Picture uploaded successfully");
 });

--- a/tests/User/PUT_user_userID_profile-picture.test.js
+++ b/tests/User/PUT_user_userID_profile-picture.test.js
@@ -4,12 +4,7 @@ const listen = require("test-listen");
 const got = require("got");
 const app = require("../../index.js");
 const {
-  userUserIDDELETE,
   userUserIDProfile_picturePUT,
-  userPOST,
-  userUserIDGET,
-  userGET,
-  userUserIDPUT,
 } = require("../../service/UserService.js");
 const { FormData, File } = require("formdata-node");
 const { FormDataEncoder } = require("form-data-encoder");

--- a/utils/formDataUtils.js
+++ b/utils/formDataUtils.js
@@ -1,0 +1,17 @@
+const { FormData, File } = require('formdata-node');
+const { FormDataEncoder } = require('form-data-encoder');
+const { Readable } = require('stream');
+
+function getFormDataDetails({ formDataFieldName, fileContent, fileName }) {
+  const formData = new FormData();
+  const file = new File([fileContent], fileName);
+  formData.set(formDataFieldName, file);
+
+  const encoder = new FormDataEncoder(formData);
+
+  return {
+    requestBody: Readable.from(encoder.encode()),
+    requestHeaders: encoder.headers,
+  };
+}
+exports.getFormDataDetails = getFormDataDetails;


### PR DESCRIPTION
- remove unused imports from test files
- extract formData request creation to a new file in order to reduce the number of import statements in file `PUT_user_userID_profile-picture.test.js`

now the maximum number of imports is 7, thus follows Cyclopt guidelines