### PR TITLE
simplify fixtures

### DIFF
--- a/fixtures/sampleAdList.js
+++ b/fixtures/sampleAdList.js
@@ -1,25 +1,20 @@
+// fixture for an array of two ads
+
 'use strict';
+
+const ad = {
+  adDescription: 'adDescription',
+  date: 'date',
+  adID: 0,
+  city: 'city',
+  title: 'title',
+  userID: 6,
+};
 
 // Array to represent a list of sample ads
 const sampleAdList = [
-  // The first ad in the list
-  {
-    adDescription: 'adDescription',
-    date: 'date',
-    adID: 0,
-    city: 'city',
-    title: 'title',
-    userID: 6,
-  },
-  // The second ad in the list
-  {
-    adDescription: 'adDescription',
-    date: 'date',
-    adID: 0,
-    city: 'city',
-    title: 'title',
-    userID: 6,
-  },
+  ad,
+  ad,
 ];
 
 // Export the sampleAdList array when this file is imported

--- a/fixtures/sampleAdListWithUsers.js
+++ b/fixtures/sampleAdListWithUsers.js
@@ -1,39 +1,30 @@
+// fixture for a sample array of two ads
+// each ad contains the user who created it
+
 'use strict';
+
+const user = {
+  profilePic: '',
+  rating: 5.962133916683182,
+  fullname: 'fullname',
+  userID: 1,
+};
+
+const ad = {
+  adDescription: 'adDescription',
+  date: 'date',
+  adID: 0,
+  city: 'city',
+  title: 'title',
+  userID: 6,
+  // The user who created the ad
+  user,
+};
 
 // Array to represent a list of sample ads with users
 const sampleAdListWithUsers = [
-  // The first ad in the list
-  {
-    adDescription: 'adDescription',
-    date: 'date',
-    adID: 0,
-    city: 'city',
-    title: 'title',
-    userID: 6,
-    // The user who created the ad
-    user: {
-      profilePic: '',
-      rating: 5.962133916683182,
-      fullname: 'fullname',
-      userID: 1,
-    },
-  },
-  // The second ad in the list
-  {
-    adDescription: 'adDescription',
-    date: 'date',
-    adID: 0,
-    city: 'city',
-    title: 'title',
-    userID: 6,
-    // The user who created the ad
-    user: {
-      profilePic: '',
-      rating: 5.962133916683182,
-      fullname: 'fullname',
-      userID: 1,
-    },
-  },
+  ad,
+  ad,
 ];
 
 // Export the sampleAdListWithUsers array when this file is imported

--- a/fixtures/sampleUserList.js
+++ b/fixtures/sampleUserList.js
@@ -1,33 +1,24 @@
+// fixture for a sample array of two users
+
 'use strict';
+
+const user = {
+  userDescription: 'userDescription',
+  gender: 'gender',
+  city: 'city',
+  phone: 'phone',
+  profilePic: '',
+  rating: 1,
+  fullname: 'fullname',
+  userID: 0,
+  email: 'email',
+  age: 6,
+};
 
 // Array to represent a list of sample users
 const sampleUserList = [
-  // The first user in the list
-  {
-    userDescription: 'userDescription',
-    gender: 'gender',
-    city: 'city',
-    phone: 'phone',
-    profilePic: '',
-    rating: 1,
-    fullname: 'fullname',
-    userID: 0,
-    email: 'email',
-    age: 6,
-  },
-  // The second user in the list
-  {
-    userDescription: 'userDescription',
-    gender: 'gender',
-    city: 'city',
-    phone: 'phone',
-    profilePic: '',
-    rating: 1,
-    fullname: 'fullname',
-    userID: 0,
-    email: 'email',
-    age: 6,
-  },
+  user,
+  user,
 ];
 
 // Export the sampleUserList array when this file is imported


### PR DESCRIPTION
I simplified the code in the fixture lists in order to improve the Cyclopt metric for maintainability
![image](https://github.com/Kyparissis/cholver-backend/assets/27917356/887c4644-0997-45a5-a14f-c4d06f0a773e)
![image](https://github.com/Kyparissis/cholver-backend/assets/27917356/31b4c2a5-389a-4013-918b-60428fe44a39)

As a result, no files are flagged:
![image](https://github.com/Kyparissis/cholver-backend/assets/27917356/ed29c3d9-e6cb-4f74-8215-4f9056a5f867)
